### PR TITLE
Fix typo in README header

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Credential Mmanifest
+# Credential Manifest
 Format that normalizes the definition of requirements for the issuance of a credential
 
 ## [Latest Editor's Draft](https://identity.foundation/credential-manifest/)


### PR DESCRIPTION
Simple fix, changes `Mmanifest` to `Manifest`