### PR TITLE
Make name optional in schema conforming to the spec text

### DIFF
--- a/schemas/credential-manifest.json
+++ b/schemas/credential-manifest.json
@@ -14,8 +14,7 @@
     "issuer": {
       "type": "object",
       "required": [
-        "id",
-        "name"
+        "id"
       ],
       "properties": {
         "id": {


### PR DESCRIPTION
> The object MAY contain a name property, and its value MUST be a string that SHOULD reflect the human-readable name the

fixes #103