### PR TITLE
remove uri json schema constraint

### DIFF
--- a/schemas/credential-manifest.json
+++ b/schemas/credential-manifest.json
@@ -26,7 +26,7 @@
           "id": { "type": "string" },
           "name": { "type": "string" },
           "description": { "type": "string" },
-          "schema": { "type": "string", "format": "uri" },
+          "schema": { "type": "string" },
           "display": {
             "type": "object",
             "properties": {

--- a/schemas/output-descriptors.json
+++ b/schemas/output-descriptors.json
@@ -11,7 +11,7 @@
           "id": { "type": "string" },
           "name": { "type": "string" },
           "description": { "type": "string" },
-          "schema": { "type": "string", "format": "uri" },
+          "schema": { "type": "string" },
           "display": {
             "type": "object",
             "properties": {


### PR DESCRIPTION
The spec text reads:
> - The [[ref:Output Descriptor Object]] ****MUST**** contain a `schema` property, and its value ****MUST**** be a string specifying the schema of the credential to be issued.

this schema is incorrect.