### PR TITLE
Adding applicant property to credential application and response

### DIFF
--- a/schemas/credential-application.json
+++ b/schemas/credential-application.json
@@ -6,6 +6,7 @@
     "id": { "type": "string" },
     "spec_version": { "type" : "string" },
     "manifest_id": { "type": "string" },
+    "applicant": { "type": "string" },
     "format": {
       "type": "object",
       "patternProperties": {

--- a/schemas/credential-response.json
+++ b/schemas/credential-response.json
@@ -5,6 +5,7 @@
   "properties": {    
     "id": { "type": "string" },
     "spec_version": { "type" : "string" },
+    "applicant": { "type": "string" },
     "manifest_id": { "type": "string" },
     "application_id": { "type": "string" },
     "fulfillment": {

--- a/spec/spec.md
+++ b/spec/spec.md
@@ -251,6 +251,7 @@ Credential Application are objects embedded within target claim negotiation form
 _Credential Applications_ are JSON objects composed as follows:
   - The object ****MUST**** contain an `id` property. The value of this property ****MUST**** be a unique identifier, such as a UUID.
   - The object ****MUST**** contain a `spec_version` property, and its value ****MUST**** be a valid spec URI according to the rules set in the [versioning section](#versioning).
+  - The object ****MUST**** contain an `applicant` property, and its value ****MUST**** be a string. The value of this property ****MUST**** be a URI which uniquely identifies the applicant.
   - The object ****MUST**** contain a `manifest_id` property. The value of this property ****MUST**** be the id of a valid Credential Manifest.
   - The object ****MUST**** have a `format` property if the related [[ref:Credential Manifest]] specifies a `format` property. Its value ****MUST**** be a _subset_ of the `format` property in the [[ref:Credential Manifest]] that this [[ref:Credential Submission]] is related to. This object informs the [[ref:Issuer]] which formats the [[ref:Holder]] wants to receive the [[ref:Claims]] in.
 - The [[ref: Credential Application]] object ****MUST**** contain a `presentation_submission` property IF the related [[ref:Credential Manifest]] contains a `presentation_definition`. Its value ****MUST**** be a valid [Presentation Submission](https://identity.foundation/presentation-exchange/#presentation-submission) as defined in the [[ref:Presentation Exchange]] specification:
@@ -296,6 +297,7 @@ The [[ref:JSON Schema]] Draft 7 definition that summarizes the rules above for [
 - The object ****MUST**** be included at the top-level of an Embed Target, or in the specific location described in the [Embed Locations table](#embed-locations) in the [Embed Target](#embed-target) section below.
 - The object ****MUST**** contain an `id` property. The value of this property ****MUST**** be a unique identifier, such as a [UUID](https://tools.ietf.org/html/rfc4122).
 - The object ****MUST**** contain a `spec_version` property, and its value ****MUST**** be a valid spec URI according to the rules set in the [versioning section](#versioning).
+- The object ****MUST**** contain an `applicant` property, and its value ****MUST**** be a string. The value of this property ****MUST**** be a URI which uniquely identifies the applicant.
 - The object ****MUST**** contain a `manifest_id` property. The value of this property ****MUST**** be the `id` value of a valid [[ref:Credential Manifest]].
 - The object ****MAY**** contain an `application_id` property. If present, the value of this property ****MUST**** be the `id` value of a valid [[ref:Credential Application]].
 - The object ****MUST**** contain **one of** the following properties depending on whether the application is to be fulfilled or rejected.

--- a/test/credential-application/appendix-jwt.json
+++ b/test/credential-application/appendix-jwt.json
@@ -2,6 +2,7 @@
   "credential_application": {
     "id": "9b1deb4d-3b7d-4bad-9bdd-2b0d7b3dcb6d",
     "spec_version": "https://identity.foundation/credential-manifest/spec/v1.0.0/",
+    "applicant": "did:example:123",
     "manifest_id": "WA-DL-CLASS-A",
     "format": {
       "ldp_vc": {

--- a/test/credential-application/appendix.json
+++ b/test/credential-application/appendix.json
@@ -10,6 +10,7 @@
   "credential_application": {
     "id": "9b1deb4d-3b7d-4bad-9bdd-2b0d7b3dcb6d",
     "spec_version": "https://identity.foundation/credential-manifest/spec/v1.0.0/",
+    "applicant": "did:example:123",
     "manifest_id": "WA-DL-CLASS-A",
     "format": {
       "ldp_vc": {

--- a/test/credential-application/sample.json
+++ b/test/credential-application/sample.json
@@ -1,6 +1,7 @@
 {
   "id": "9b1deb4d-3b7d-4bad-9bdd-2b0d7b3dcb6d",
   "spec_version": "https://identity.foundation/credential-manifest/spec/v1.0.0/",
+  "applicant": "did:example:123",
   "manifest_id": "WA-DL-CLASS-A",
   "format": {
     "ldp_vc": {

--- a/test/credential-response/appendix-jwt.json
+++ b/test/credential-response/appendix-jwt.json
@@ -1,6 +1,7 @@
 {
   "credential_response": {
     "application_id": "9b1deb4d-3b7d-4bad-9bdd-2b0d7b3dcb6d",
+    "applicant": "did:example:123",
     "fulfillment": {
       "descriptor_map": [
         {

--- a/test/credential-response/appendix.json
+++ b/test/credential-response/appendix.json
@@ -10,6 +10,7 @@
   "credential_response": {
     "id": "a30e3b91-fb77-4d22-95fa-871689c322e2",
     "spec_version": "https://identity.foundation/credential-manifest/spec/v1.0.0/",
+    "applicant": "did:example:123",
     "manifest_id": "32f54163-7166-48f1-93d8-ff217bdb0653",
     "application_id": "9b1deb4d-3b7d-4bad-9bdd-2b0d7b3dcb6d",
     "fulfillment": {

--- a/test/credential-response/sample-denial.json
+++ b/test/credential-response/sample-denial.json
@@ -1,6 +1,7 @@
 {
   "id": "a30e3b91-fb77-4d22-95fa-871689c322e2",
   "spec_version": "https://identity.foundation/credential-manifest/spec/v1.0.0/",
+  "applicant": "did:example:123",
   "manifest_id": "32f54163-7166-48f1-93d8-ff217bdb0653",
   "application_id": "b6385066-147c-49d0-9783-261a2154b1fd",
   "denial": {

--- a/test/credential-response/sample-fulfillment.json
+++ b/test/credential-response/sample-fulfillment.json
@@ -1,6 +1,7 @@
 {
   "id": "a30e3b91-fb77-4d22-95fa-871689c322e2",
   "spec_version": "https://identity.foundation/credential-manifest/spec/v1.0.0/",
+  "applicant": "did:example:123",
   "manifest_id": "32f54163-7166-48f1-93d8-ff217bdb0653",
   "application_id": "b6385066-147c-49d0-9783-261a2154b1fd",
   "fulfillment": {


### PR DESCRIPTION
The Credential Manifest specifies an issuer property, showing who created it. A Credential Application does not show who the applicant is outside of the credential(s) they provide that may include their identifier. Similarly, a Credential Response has an application_id which shows which application it is responding to, but no mention of who the applicant is.

I'd like to propose a change to add an applicant field to both Credential Applications and Credential Responses to make it explicit the parties involved in the interaction.

Based on this discussion from @decentralgabe - https://github.com/decentralized-identity/credential-manifest/issues/132