### PR TITLE
move stable spec versions to /spec/ path

### DIFF
--- a/spec/spec.md
+++ b/spec/spec.md
@@ -7,7 +7,7 @@ Credential Manifest 1.x Editor's Draft
   [identity.foundation/credential-manifest](https://identity.foundation/credential-manifest)
 
 **Stable Working-Group Approved Draft:**
-  [identity.foundation/credential-manifest/v1.0.0](https://identity.foundation/credential-manifest/v1.0.0)
+  [identity.foundation/credential-manifest/spec/v1.0.0](https://identity.foundation/credential-manifest/v1.0.0)
 
 
 **Editors:**

--- a/spec/v1.0.0/spec/spec.md
+++ b/spec/v1.0.0/spec/spec.md
@@ -7,7 +7,7 @@ Credential Manifest 1.0.0 Working-Group Draft
   [identity.foundation/credential-manifest](https://identity.foundation/credential-manifest)
 
 **Stable Working-Group Approved Draft:**
-  [identity.foundation/credential-manifest/v1.0.0](https://identity.foundation/credential-manifest/v1.0.0)
+  [identity.foundation/credential-manifest/spec/v1.0.0](https://identity.foundation/credential-manifest/v1.0.0)
 
 
 **Editors:**

--- a/specs.json
+++ b/specs.json
@@ -16,7 +16,7 @@
     {
       "title": "DIF Credential Manifest",
       "spec_directory": "./spec/v1.0.0/spec",
-      "output_path": "./build/v1.0.0",
+      "output_path": "./build/spec/v1.0.0",
       "logo": "https://rawcdn.githack.com/decentralized-identity/decentralized-identity.github.io/a3ca39717e440302d1fd99a796e7f00e1c42eb2d/images/logo-flat.svg",
       "logo_link": "https://identity.foundation",
       "source": {


### PR DESCRIPTION
closes #148 